### PR TITLE
Add RBAC schema and tooling

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,15 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: quantisti-postgres
+    environment:
+      POSTGRES_USER: quantisti
+      POSTGRES_PASSWORD: quantisti
+      POSTGRES_DB: quantisti
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/docs/security-rbac.md
+++ b/docs/security-rbac.md
@@ -1,0 +1,53 @@
+# Security RBAC Policy
+
+This document outlines the role-based access control (RBAC) model for the Quantisti options trading platform.
+
+## Roles
+- **Basic** – Entry-level access for general market visibility.
+- **Premium** – Enhanced access for paid subscribers.
+- **Admin** – Full administrative control over the platform.
+
+## Permissions
+Permissions are defined by the `resource:action` pair.
+
+| Resource | Actions |
+|----------|---------|
+| `market` | `candles:read`, `option_chain:read` |
+| `simulator` | `run:write`, `export:read` |
+| `portfolio` | `read`, `write` |
+| `stats` | `basic:read`, `risk:read` |
+| `ml` | `predict:read` |
+| `explain` | `shap:read` |
+| `admin` | `users:write`, `roles:write`, `audit:read`, `services:read` |
+
+## Role to Permission Matrix
+
+| Role    | Permissions |
+|---------|-------------|
+| **Basic** | `market:candles:read`, `market:option_chain:read`, `simulator:run:write`, `portfolio:read`, `stats:basic:read` |
+| **Premium** | All **Basic** permissions plus `simulator:export:read`, `portfolio:write`, `stats:risk:read`, `ml:predict:read`, `explain:shap:read` |
+| **Admin** | All permissions including all `admin:*` capabilities |
+
+- Basic users do **not** receive access to simulator exports, premium analytics, ML, explainability, or admin endpoints.
+- Premium users gain all Basic access along with additional analytics, ML, explainability, and export capabilities.
+- Admin users receive full access, including administrative management and observability endpoints.
+
+## Route Map
+
+| Route Pattern | Required Permission |
+|---------------|---------------------|
+| `/market/candles` | `market:candles:read` |
+| `/market/option-chain` | `market:option_chain:read` |
+| `/simulate/*` | `simulator:run:write` |
+| `/simulate/{id}/export` | `simulator:export:read` |
+| `/portfolio/*` (GET) | `portfolio:read` |
+| `/portfolio/*` (POST/PUT/PATCH) | `portfolio:write` |
+| `/stats/basic/*` | `stats:basic:read` |
+| `/stats/risk/*` | `stats:risk:read` |
+| `/ml/predict` | `ml:predict:read` |
+| `/explain/shap` | `explain:shap:read` |
+| `/admin/users/*` | `admin:users:write` |
+| `/admin/roles/*` | `admin:roles:write` |
+| `/admin/audit` | `admin:audit:read` |
+| `/admin/services/health` | `admin:services:read` |
+

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,36 @@
+# RBAC Schema Setup
+
+This directory contains SQL files and documentation for applying the role-based access control (RBAC) schema.
+
+## Prerequisites
+- A reachable PostgreSQL instance.
+- `DATABASE_URL` environment variable pointing to the target database.
+
+## Optional: Start a local PostgreSQL instance
+If you need a local database, you can launch one with the provided Compose overlay:
+
+```bash
+docker compose -f docker-compose.db.yml up -d
+```
+
+## Configure database connection
+Export your database connection string before applying migrations. Example for the local Compose service:
+
+```bash
+export DATABASE_URL=postgresql://quantisti:quantisti@localhost:5432/quantisti
+```
+
+## Apply schema and seed data
+Run the helper script to apply all SQL files in order:
+
+```bash
+bash scripts/db_apply.sh
+```
+
+## Verify the schema
+Use `psql` to inspect the resulting tables and permissions:
+
+```bash
+psql "$DATABASE_URL" -c "TABLE roles;"
+psql "$DATABASE_URL" -c "SELECT r.name, p.resource, p.action\n                       FROM roles r\n                       JOIN role_permissions rp ON rp.role_id = r.id\n                       JOIN permissions p ON p.id = rp.permission_id\n                       ORDER BY r.name, p.resource, p.action;"
+```

--- a/schema/sql/001_create_tables.sql
+++ b/schema/sql/001_create_tables.sql
@@ -1,0 +1,49 @@
+-- RBAC core tables
+CREATE TABLE IF NOT EXISTS users (
+    uid TEXT PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'disabled')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS roles (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS permissions (
+    id BIGSERIAL PRIMARY KEY,
+    resource TEXT NOT NULL,
+    action TEXT NOT NULL,
+    CONSTRAINT permissions_uniq UNIQUE (resource, action)
+);
+
+CREATE TABLE IF NOT EXISTS user_roles (
+    user_uid TEXT NOT NULL REFERENCES users(uid) ON DELETE CASCADE,
+    role_id BIGINT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_uid, role_id)
+);
+
+CREATE TABLE IF NOT EXISTS role_permissions (
+    role_id BIGINT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    permission_id BIGINT NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+    PRIMARY KEY (role_id, permission_id)
+);
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+    id BIGSERIAL PRIMARY KEY,
+    user_uid TEXT,
+    resource TEXT,
+    action TEXT,
+    decision TEXT CHECK (decision IN ('allow', 'deny')),
+    trace_id TEXT,
+    ts TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Optional trigger to update users.updated_at could be added here if needed.
+
+CREATE INDEX IF NOT EXISTS idx_user_roles_user ON user_roles(user_uid);
+CREATE INDEX IF NOT EXISTS idx_role_perms_role ON role_permissions(role_id);
+CREATE INDEX IF NOT EXISTS idx_permissions_resource_action ON permissions(resource, action);

--- a/schema/sql/002_seed_rbac.sql
+++ b/schema/sql/002_seed_rbac.sql
@@ -1,0 +1,64 @@
+-- Seed RBAC roles and permissions
+INSERT INTO roles (name, description) VALUES
+  ('Basic',   'Basic user with limited access'),
+  ('Premium', 'Premium user with full features'),
+  ('Admin',   'Administrator with full control')
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO permissions (resource, action) VALUES
+  ('market',   'candles:read'),
+  ('market',   'option_chain:read'),
+  ('simulator','run:write'),
+  ('simulator','export:read'),
+  ('portfolio','read'),
+  ('portfolio','write'),
+  ('stats',    'basic:read'),
+  ('stats',    'risk:read'),
+  ('ml',       'predict:read'),
+  ('explain',  'shap:read'),
+  ('admin',    'users:write'),
+  ('admin',    'roles:write'),
+  ('admin',    'audit:read'),
+  ('admin',    'services:read')
+ON CONFLICT (resource, action) DO NOTHING;
+
+-- Map Basic role permissions
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON (p.resource, p.action) IN (
+    ('market', 'candles:read'),
+    ('market', 'option_chain:read'),
+    ('simulator', 'run:write'),
+    ('portfolio', 'read'),
+    ('stats', 'basic:read')
+)
+WHERE r.name = 'Basic'
+ON CONFLICT DO NOTHING;
+
+-- Map Premium role permissions
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN permissions p ON (p.resource, p.action) IN (
+    ('market', 'candles:read'),
+    ('market', 'option_chain:read'),
+    ('simulator', 'run:write'),
+    ('simulator', 'export:read'),
+    ('portfolio', 'read'),
+    ('portfolio', 'write'),
+    ('stats', 'basic:read'),
+    ('stats', 'risk:read'),
+    ('ml', 'predict:read'),
+    ('explain', 'shap:read')
+)
+WHERE r.name = 'Premium'
+ON CONFLICT DO NOTHING;
+
+-- Map Admin role permissions (all permissions)
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+CROSS JOIN permissions p
+WHERE r.name = 'Admin'
+ON CONFLICT DO NOTHING;

--- a/schema/sql/003_sample_users.sql
+++ b/schema/sql/003_sample_users.sql
@@ -1,0 +1,18 @@
+-- Sample data for local testing (comment out in production environments)
+INSERT INTO users (uid, email) VALUES
+  ('user_basic_1', 'basic@example.com'),
+  ('user_premium_1', 'premium@example.com'),
+  ('user_admin_1', 'admin@example.com')
+ON CONFLICT (uid) DO NOTHING;
+
+INSERT INTO user_roles (user_uid, role_id)
+SELECT 'user_basic_1', id FROM roles WHERE name = 'Basic'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO user_roles (user_uid, role_id)
+SELECT 'user_premium_1', id FROM roles WHERE name = 'Premium'
+ON CONFLICT DO NOTHING;
+
+INSERT INTO user_roles (user_uid, role_id)
+SELECT 'user_admin_1', id FROM roles WHERE name = 'Admin'
+ON CONFLICT DO NOTHING;

--- a/scripts/db_apply.sh
+++ b/scripts/db_apply.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL is not set. Please export it before running this script." >&2
+  exit 1
+fi
+
+shopt -s nullglob
+sql_files=(schema/sql/*.sql)
+if [ ${#sql_files[@]} -eq 0 ]; then
+  echo "No SQL files found in schema/sql." >&2
+  exit 1
+fi
+
+for file in "${sql_files[@]}"; do
+  echo "Applying $file"
+  if command -v psql >/dev/null 2>&1; then
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
+  else
+    if ! command -v docker >/dev/null 2>&1; then
+      echo "psql not found and docker is unavailable. Cannot apply $file." >&2
+      exit 1
+    fi
+    docker run --rm \
+      -e DATABASE_URL="$DATABASE_URL" \
+      -v "$PWD:/work" \
+      -w /work \
+      postgres:16 \
+      psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
+  fi
+done
+
+echo "Done."


### PR DESCRIPTION
## Summary
- add PostgreSQL RBAC schema with users, roles, permissions, and audit tables
- seed baseline roles, permissions, and optional sample users for local testing
- document RBAC policy, provide database apply script, and optional Postgres compose overlay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcb14cc41c832185554a10f191e42f