### PR TITLE
fix: Register UUID adapter for psycopg2 to resolve backtest creation …

### DIFF
--- a/services/simulator/app/db/connection.py
+++ b/services/simulator/app/db/connection.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 import psycopg2
 from psycopg2 import pool
-from psycopg2.extras import RealDictCursor
+from psycopg2.extras import RealDictCursor, register_uuid
 
 from ..config import get_settings
 
@@ -68,6 +68,10 @@ def initialize_pool(min_conn: int = 1, max_conn: int = 10):
             settings.DATABASE_URL
         )
         logger.info(f"Database connection pool initialized (min={min_conn}, max={max_conn})")
+
+        # Register UUID adapter for psycopg2
+        register_uuid()
+        logger.info("UUID adapter registered for PostgreSQL")
 
         # Test connection
         conn = get_db_connection()


### PR DESCRIPTION
…error

Fixes the 'can't adapt type UUID' error when creating backtests by registering the UUID adapter with psycopg2 during database connection pool initialization.

This allows psycopg2 to properly convert Python UUID objects to PostgreSQL UUID types when executing queries with UUID parameters.

Changes:
- Import register_uuid from psycopg2.extras
- Call register_uuid() during pool initialization
- Add logging for UUID adapter registration

Resolves: UUID adaptation error in POST /v1/backtests/